### PR TITLE
Move _config.txt <user home>/.LATTE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ README_pip.md
 MANIFEST.in
 pyaneti_LATTE
 pyaneti_LATTE.py
-./_config.txt
-./LATTE/_config.txt
+_LATTE_test_config/
+_LATTE_test_config*

--- a/LATTE/LATTEconfig.py
+++ b/LATTE/LATTEconfig.py
@@ -1,0 +1,40 @@
+import os
+
+
+class LATTEconfig(object):
+	"""Provide configuration for LATTE"""
+
+	_config_dir = None
+
+	def __init__(self, config_dir=None):
+		if config_dir is None:
+			config_dir = os.path.join(os.path.expanduser('~'), '.LATTE')
+
+		if os.path.isdir(config_dir):
+			self._config_dir = config_dir
+			return
+		else:
+			# if it doesn't exist, make a new directory
+			try:
+				os.mkdir(config_dir)
+				self._config_dir = config_dir
+			except OSError as ose:
+				msg = "LATTE config directory does not exist, and cannot be created: {}".format(config_dir)
+				raise ValueError(msg) from ose
+
+	@property
+	def output_path(self):
+		"""LATTE's output path."""
+		with open("{}/_config.txt".format(self._config_dir), 'r') as f:
+			return str(f.readlines()[-1])
+
+	@output_path.setter
+	def output_path(self, output_path):
+		with open("{}/_config.txt".format(self._config_dir), 'w') as f:
+			f.write(str(output_path))
+
+	@property
+	def inited(self):
+		"""return ``True`` if configuration exists."""
+		return os.path.exists("{}/_config.txt".format(self._config_dir))
+

--- a/LATTE/__main__.py
+++ b/LATTE/__main__.py
@@ -19,6 +19,7 @@ from tess_stars2px import tess_stars2px_function_entry
 #custom modules to import
 from LATTE import LATTEbrew as brew 
 from LATTE import LATTEutils as utils
+from LATTE.LATTEconfig import LATTEconfig
 #sys.tracebacklimit = 0
 warnings.filterwarnings('ignore')
 
@@ -70,10 +71,12 @@ if __name__ == '__main__':
 
 
 	# ------------------------------------------------
-	# Check what the current path is - when the program is first downloaded the path is set to 'no/path/set/yet' and the user is automatically prompted to change'no/path/set/yet'
-	# Get the path to where the package is installed. This is where the configuration file and the images (for the DV report are stored)
-
+	# the current path - used to resolve other files in the package, e.g., pyaneti_LATTE.py
 	syspath = str(os.path.abspath(utils.__file__))[0:-14]
+
+	# configuration file that defines the directory where output are stored, e.g., images, DV reports.
+	# The user will be prompted to set it when the program is run the first time.
+	config = LATTEconfig()
 	# ----------
 
 	def yes_or_no():
@@ -101,7 +104,7 @@ if __name__ == '__main__':
 	'''
 
 	# check whether a path already exists
-	if not os.path.exists("{}/_config.txt".format(syspath)):
+	if not config.inited:
 
 		# if it doesn't exist ask the user to put it in the command line
 		indir = input("\n \n No output path has been set yet. \n \n Please enter a path to save the files (e.g. ./LATTE_output or /Users/yourname/Desktop/LATTE_output) : " )
@@ -124,8 +127,7 @@ if __name__ == '__main__':
 			sys.exit('')
 
 		# SAVE the new output path
-		with open("{}/_config.txt".format(syspath),'w') as f:
-			f.write(str(indir))
+		config.output_path = indir
 		
 		print("\n New path: " + indir)
 	
@@ -177,8 +179,7 @@ if __name__ == '__main__':
 				sys.exit('')
 	
 			# SAVE the new output path
-			with open("{}/_config.txt".format(syspath),'w') as f:
-				f.write(str(indir))	
+			config.output_path = indir
 			
 			print("\n New path: " + indir)
 			
@@ -187,8 +188,7 @@ if __name__ == '__main__':
 
 
 		else:
-			with open("{}/_config.txt".format(syspath), 'r') as f:
-				indir = str(f.readlines()[-1])
+			indir = config.output_path
 				
 			print ("LATTE will continue to run with the old path: {}".format(indir))
 
@@ -211,16 +211,14 @@ if __name__ == '__main__':
 	
 			if intry > 0:
 				# SAVE the new output path
-				with open("{}/_config.txt".format(syspath),'w') as f:
-					f.write(str(indir))	
+				indir = config.output_path
 
 			if not os.path.exists("{}/data".format(indir)):
 				os.makedirs("{}/data".format(indir))
 				
 
 	else:
-		with open("{}/_config.txt".format(syspath), 'r') as f:
-			indir = str(f.readlines()[-1])
+		indir = config.output_path
 	
 
 		#try three times to find the output path
@@ -242,9 +240,7 @@ if __name__ == '__main__':
 	
 		if intry > 0:
 			# SAVE the new output path
-			with open("{}/_config.txt".format(syspath),'w') as f:
-				f.write(str(indir))	
-
+			config.output_path = indir
 
 		if not os.path.exists("{}/data".format(indir)):
 			os.makedirs("{}/data".format(indir))
@@ -258,7 +254,7 @@ if __name__ == '__main__':
 	The program will check what data has already been downloaded and only download new data files.
 	'''
 
-	if (args.new_data != False) and (os.path.exists("{}/_config.txt".format(syspath))): 
+	if (args.new_data != False) and config.inited:
 
 		# ----- REFERENCE FILES DOWNLOAD -----
 		#utils.data_files(indir)

--- a/LATTE/_config.txt
+++ b/LATTE/_config.txt
@@ -1,1 +1,0 @@
-/Users/Nora/Documents/research/TESS/planethunters/code/LATTE/LATTE/LATTE_output/

--- a/LATTE/tests/test_config.py
+++ b/LATTE/tests/test_config.py
@@ -1,0 +1,62 @@
+
+'''
+Unit test for LATTE configuration logic.
+'''
+import os
+import shutil
+import unittest
+
+from LATTE.LATTEconfig import LATTEconfig
+
+
+class TestLATTEconfig(unittest.TestCase):
+
+	config_dir_for_test = os.path.join(os.path.dirname(__file__), '_LATTE_test_config')
+
+	def setUp(self):
+		# Note: we do not remove config dir at tearDown(),
+		# so that in case tests fail, one can inspect the content
+		if os.path.exists(self.config_dir_for_test):
+			shutil.rmtree(self.config_dir_for_test)
+
+	def test_typical(self):
+		# Test initial output path assignment, starting with no config dir exist
+		config = LATTEconfig(self.config_dir_for_test)
+		assert config.inited is False
+
+		output_path_a = 'latteDataA'
+		config.output_path = output_path_a
+		assert config.output_path == output_path_a
+		assert config.inited is True
+
+		# Ensure the setting is persisted by using another instance
+		config2 = LATTEconfig(self.config_dir_for_test)
+		assert config2.output_path == output_path_a
+
+        #
+		# Now test updating the path
+		#
+		output_path_b = 'latteDataB'
+		config2.output_path = output_path_b
+		assert config2.output_path == output_path_b
+
+		# ensure the setting is persisted
+		assert config.output_path == output_path_b
+
+
+	def test_config_dir_cannot_be_created(self):
+		config_dir_for_fail = os.path.join(os.path.dirname(__file__), '_LATTE_test_config_fail')
+		with open(config_dir_for_fail, 'w') as f:
+			f.write("Config dir failure case: the path is an existing file")
+
+		with self.assertRaises(ValueError) as context:
+			config = LATTEconfig(config_dir_for_fail)
+		# clean up
+		os.remove(config_dir_for_fail)
+
+
+
+if __name__ == '__main__':
+
+	unittest.main()
+

--- a/LATTE/tests/test_data_download.py
+++ b/LATTE/tests/test_data_download.py
@@ -17,12 +17,10 @@ import warnings
 
 warnings.filterwarnings("ignore")
 from LATTE import LATTEutils
+from LATTE.LATTEconfig import LATTEconfig
 
-# get the outir (or indir) path
-syspath = str(os.path.abspath(LATTEutils.__file__))[0:-14]
-
-with open("{}/_config.txt".format(syspath), 'r') as f:
-	outdir = str(f.readlines()[-1])
+# get the outdir path
+outdir = LATTEconfig().output_path
 
 class TestTESSpoint(unittest.TestCase):
 

--- a/LATTE/tests/test_server_response.py
+++ b/LATTE/tests/test_server_response.py
@@ -13,16 +13,6 @@ import requests
 
 import warnings
 warnings.filterwarnings("ignore")
-
-import sys
-import LATTE.LATTEutils as utils
-
-# test the downloading of the data
-# get the outir (or indir) path
-syspath = str(os.path.abspath(utils.__file__))[0:-14]
-
-with open("{}/_config.txt".format(syspath), 'r') as f:
-	indir = str(f.readlines()[-1])
 		
 def download_LC_data():
 	# function to reach the external server to download the scipt - this is for the first sector only

--- a/example_parallelized_code.py
+++ b/example_parallelized_code.py
@@ -23,10 +23,15 @@ from argparse import ArgumentParser
 
 import LATTE
 from LATTE import LATTEutils, LATTEbrew
+from LATTE.LATTEconfig import LATTEconfig
 import sys
 
 # get the system path
 syspath = str(os.path.abspath(LATTEutils.__file__))[0:-14]
+
+# configuration file that defines the directory where output are stored, e.g., images, DV reports.
+# The user will be prompted to set it when the program is run the first time.
+config = LATTEconfig()
 
 # set up for supercomputer
 try:
@@ -212,14 +217,13 @@ if __name__ == '__main__':
 	args.mpi = True
 
 	# check whether a path already exists
-	if not os.path.exists("{}/_config.txt".format(syspath)):
+	if not config.inited:
 	
 		# if it doesn't exist ask the user to put it in the command line
 		indir = input("\n \n No output path has been set yet. \n \n Please enter a path to save the files (e.g. ./LATTE_output or /Users/yourname/Desktop/LATTE_output) : " )
 	
 		# SAVE the new output path
-		with open("{}/_config.txt".format(syspath),'w') as f:
-			f.write(str(indir))
+		config.output_path = indir
 		
 		print("\n New path: " + indir)
 	
@@ -254,20 +258,17 @@ if __name__ == '__main__':
 			indir = input("\n \n Please enter a path to save the files (e.g. ./LATTE_output or /Users/yourname/Desktop/LATTE_output) : " )
 	
 			# SAVE the new output path
-			with open("{}/_config.txt".format(syspath),'w') as f:
-				f.write(str(indir))	
+			config.output_path = indir
 			
 			print("\n New path: " + indir)
 		
 		else:
-			with open("{}/_config.txt".format(syspath), 'r') as f:
-				indir = str(f.readlines()[-1])
+			indir = config.output_path
 		
 			print ("LATTE will continue to run with the old path: {}".format(indir))
 	
 	else:
-		with open("{}/_config.txt".format(syspath), 'r') as f:
-			indir = str(f.readlines()[-1])
+		indir = config.output_path
 	
 	if args.targetlist == 'no':
 		print ("You need to provide an input target list to run this code. End.")


### PR DESCRIPTION
Move `LATTE/_config.txt` to `<user_home>/.LATTE/_config.txt`, so that
- each user has its own config
- the config would survive LATTE version upgrade (as it's located outside of the package)
- On `LATTE-dev`, developers won't have their settings lost, overridden the the committed `_config.txt`

Addressed part of #21 

Currently, it does not support migration from the old `LATTE/_config.txt` to `<user_home>/.LATTE/_config.txt`. It can be added if so desired.
