### PR TITLE
Sklearn deprecated fix + python version suggestion + urllib3 version [June 2024]

### DIFF
--- a/LATTE/LATTE_DV.py
+++ b/LATTE/LATTE_DV.py
@@ -685,18 +685,19 @@ def LATTE_DV(tic, indir, syspath, transit_list, sectors_all, target_ra, target_d
 				data_bls= [['Parameter',				  "bls1",														"bls2"],
 							   ['period',			    "{:.3f}".format(bls_stats1[0]),	         						 "{:.3f}".format(bls_stats2[0])],
 							   ['t0',			        "{:.2f}".format(bls_stats1[1]),	         						 "{:.2f}".format(bls_stats2[1])],
-							   ['depth',			    "{:.5f} ± {:.5f}".format(bls_stats1[2][0],bls_stats1[2][1]),	 "{:.5f} ± {:.5f}".format(bls_stats2[2][0],bls_stats2[2][1]) ],
-							   ['depth phased',			"{:.5f} ± {:.5f}".format(bls_stats1[3][0],bls_stats1[3][1]),	 "{:.5f} ± {:.5f}".format(bls_stats2[3][0],bls_stats2[3][1]) ],
-							   ['depth half',			"{:.5f} ± {:.5f}".format(bls_stats1[4][0],bls_stats1[4][1]),	 "{:.5f} ± {:.5f}".format(bls_stats2[4][0],bls_stats2[4][1]) ],
-							   ['depth odd',			"{:.5f} ± {:.5f}".format(bls_stats1[5][0],bls_stats1[5][1]),	 "{:.5f} ± {:.5f}".format(bls_stats2[5][0],bls_stats2[5][1]) ],
-							   ['depth even',			"{:.5f} ± {:.5f}".format(bls_stats1[6][0],bls_stats1[6][1]),	 "{:.5f} ± {:.5f}".format(bls_stats2[6][0],bls_stats2[6][1]) ],
+						       ['duration',             "{:.5f}".format(bls_stats1[2]),	         						 "{:.5f}".format(bls_stats2[2])],
+							   ['depth',			    "{:.5f} ± {:.5f}".format(bls_stats1[3][0],bls_stats1[3][1]),	 "{:.5f} ± {:.5f}".format(bls_stats2[3][0],bls_stats2[3][1]) ],
+							   ['depth phased',			"{:.5f} ± {:.5f}".format(bls_stats1[4][0],bls_stats1[4][1]),	 "{:.5f} ± {:.5f}".format(bls_stats2[4][0],bls_stats2[4][1]) ],
+							   ['depth half',			"{:.5f} ± {:.5f}".format(bls_stats1[5][0],bls_stats1[5][1]),	 "{:.5f} ± {:.5f}".format(bls_stats2[5][0],bls_stats2[5][1]) ],
+							   ['depth odd',			"{:.5f} ± {:.5f}".format(bls_stats1[6][0],bls_stats1[6][1]),	 "{:.5f} ± {:.5f}".format(bls_stats2[6][0],bls_stats2[6][1]) ],
+							   ['depth even',			"{:.5f} ± {:.5f}".format(bls_stats1[7][0],bls_stats1[7][1]),	 "{:.5f} ± {:.5f}".format(bls_stats2[7][0],bls_stats2[7][1]) ],
 							   ]
 
 				table_bls=Table(data_bls)
 				table_bls=Table(data_bls,colWidths=width * 0.2, style=[
 									('LINEABOVE',(0,1),(-1,1),1,colors.black),
-									('LINEABOVE',(0,8),(-1,8),1,colors.black),
-									('FONTSIZE', (0,0),(-1,7), 8),
+									('LINEABOVE',(0,9),(-1,9),1,colors.black),
+									('FONTSIZE', (0,0),(-1,8), 8),
 									])
 
 			else: # if the first BLS returned a period that was very short such that the second one didn't work.
@@ -738,17 +739,18 @@ def LATTE_DV(tic, indir, syspath, transit_list, sectors_all, target_ra, target_d
 				data_bls= [['Parameter',				  "bls1"													 ],
 							   ['period',			    "{:.3f}".format(bls_stats1[0])	         					 ],
 							   ['t0',			        "{:.2f}".format(bls_stats1[1])	         					 ],
-							   ['depth',			    "{:.5f} ± {:.5f}".format(bls_stats1[2][0],bls_stats1[2][1])	 ],
-							   ['depth phased',			"{:.5f} ± {:.5f}".format(bls_stats1[3][0],bls_stats1[3][1])	 ],
-							   ['depth half',			"{:.5f} ± {:.5f}".format(bls_stats1[4][0],bls_stats1[4][1])	 ],
-							   ['depth odd',			"{:.5f} ± {:.5f}".format(bls_stats1[5][0],bls_stats1[5][1])	 ],
-							   ['depth even',			"{:.5f} ± {:.5f}".format(bls_stats1[6][0],bls_stats1[6][1])	 ],
+							   ['duration',			    "{:.5f}".format(bls_stats1[2])	         					 ],
+							   ['depth',			    "{:.5f} ± {:.5f}".format(bls_stats1[3][0],bls_stats1[3][1])	 ],
+							   ['depth phased',			"{:.5f} ± {:.5f}".format(bls_stats1[4][0],bls_stats1[4][1])	 ],
+							   ['depth half',			"{:.5f} ± {:.5f}".format(bls_stats1[5][0],bls_stats1[5][1])	 ],
+							   ['depth odd',			"{:.5f} ± {:.5f}".format(bls_stats1[6][0],bls_stats1[6][1])	 ],
+							   ['depth even',			"{:.5f} ± {:.5f}".format(bls_stats1[7][0],bls_stats1[7][1])	 ],
 							   ]
 
 				table_bls=Table(data_bls)
 				table_bls=Table(data_bls,colWidths=width * 0.25, style=[
 									('LINEABOVE',(0,1),(-1,1),1,colors.black),
-									('LINEABOVE',(0,8),(-1,8),1,colors.black),
+									('LINEABOVE',(0,9),(-1,9),1,colors.black),
 									('FONTSIZE', (0,0),(-1,7), 8),
 									])
 

--- a/LATTE/LATTEutils.py
+++ b/LATTE/LATTEutils.py
@@ -5824,6 +5824,7 @@ def data_bls(tic, indir, alltime, allflux, allfluxbinned, alltimebinned, args):
         two lists of the statistics of the to BLS runs. Each list contains:
     stats_period
     stats_t0
+    stats_duration
     stats_depth
     stats_depth_phased
     stats_depth_half
@@ -5909,6 +5910,7 @@ def data_bls(tic, indir, alltime, allflux, allfluxbinned, alltimebinned, args):
 
     stats_period = period
     stats_t0 = mid_transit_t0
+    stats_duration = duration
     stats_depth = model.compute_stats(period, duration, t0)['depth']
     stats_depth_phased = model.compute_stats(period, duration, t0)['depth_phased']
     stats_depth_half = model.compute_stats(period, duration, t0)['depth_half']
@@ -5917,7 +5919,7 @@ def data_bls(tic, indir, alltime, allflux, allfluxbinned, alltimebinned, args):
 
 
     if (2*duration) >= period: # if the 'found' events are very short period, don't rn the BLS twice as the code would crash.
-        return [stats_period, stats_t0, stats_depth, stats_depth_phased, stats_depth_half, stats_depth_odd, stats_depth_even], [-999]
+        return [stats_period, stats_t0, stats_duration, stats_depth, stats_depth_phased, stats_depth_half, stats_depth_odd, stats_depth_even], [-999]
 
     # Find the in-transit points using a longer duration as a buffer to avoid ingress and egress
     in_transit = model.transit_mask(alltimebinned, period, 2*duration, t0)
@@ -5939,13 +5941,14 @@ def data_bls(tic, indir, alltime, allflux, allfluxbinned, alltimebinned, args):
 
     stats2_period = period2
     stats2_t0 = mid_transit_t02
+    stats2_duration = duration2
     stats2_depth = model2.compute_stats(period2, duration2, t0)['depth']
     stats2_depth_phased = model2.compute_stats(period2, duration2, t0)['depth_phased']
     stats2_depth_half = model2.compute_stats(period2, duration2, t0)['depth_half']
     stats2_depth_odd = model2.compute_stats(period2, duration2, t0)['depth_odd']
     stats2_depth_even = model2.compute_stats(period2, duration2, t0)['depth_even']
 
-    return [stats_period, stats_t0, stats_depth, stats_depth_phased, stats_depth_half, stats_depth_odd, stats_depth_even], [stats2_period, stats2_t0, stats2_depth, stats2_depth_phased, stats2_depth_half, stats2_depth_odd, stats2_depth_even]
+    return [stats_period, stats_t0, stats_duration, stats_depth, stats_depth_phased, stats_depth_half, stats_depth_odd, stats_depth_even], [stats2_period, stats2_t0, stats2_duration, stats2_depth, stats2_depth_phased, stats2_depth_half, stats2_depth_odd, stats2_depth_even]
 
 def data_bls_FFI(tic, indir, alltime, allflux, args):
     '''
@@ -5967,6 +5970,7 @@ def data_bls_FFI(tic, indir, alltime, allflux, args):
         two lists of the statistics of the to BLS runs. Each list contains:
     stats_period
     stats_t0
+    stats_duration
     stats_depth
     stats_depth_phased
     stats_depth_half
@@ -6004,6 +6008,7 @@ def data_bls_FFI(tic, indir, alltime, allflux, args):
 
     stats_period = period
     stats_t0 = t0
+    stats_duration = duration
     stats_depth = model.compute_stats(period, duration, t0)['depth']
     stats_depth_phased = model.compute_stats(period, duration, t0)['depth_phased']
     stats_depth_half = model.compute_stats(period, duration, t0)['depth_half']
@@ -6012,7 +6017,7 @@ def data_bls_FFI(tic, indir, alltime, allflux, args):
 
 
     if (2*duration) >= period: # if the 'found' events are very short period, don't rn the BLS twice as the code would crash.
-        return [stats_period, stats_t0, stats_depth, stats_depth_phased, stats_depth_half, stats_depth_odd, stats_depth_even], [-999]
+        return [stats_period, stats_t0, stats_duration, stats_depth, stats_depth_phased, stats_depth_half, stats_depth_odd, stats_depth_even], [-999]
 
 
     # Find the in-transit points using a longer duration as a buffer to avoid ingress and egress
@@ -6033,13 +6038,14 @@ def data_bls_FFI(tic, indir, alltime, allflux, args):
 
     stats2_period = period2
     stats2_t0 = t02
+    stats2_duration = duration2
     stats2_depth = model2.compute_stats(period2, duration2, t0)['depth']
     stats2_depth_phased = model2.compute_stats(period2, duration2, t0)['depth_phased']
     stats2_depth_half = model2.compute_stats(period2, duration2, t0)['depth_half']
     stats2_depth_odd = model2.compute_stats(period2, duration2, t0)['depth_odd']
     stats2_depth_even = model2.compute_stats(period2, duration2, t0)['depth_even']
 
-    return [stats_period, stats_t0, stats_depth, stats_depth_phased, stats_depth_half, stats_depth_odd, stats_depth_even], [stats2_period, stats2_t0, stats2_depth, stats2_depth_phased, stats2_depth_half, stats2_depth_odd, stats2_depth_even]
+    return [stats_period, stats_t0, stats_duration, stats_depth, stats_depth_phased, stats_depth_half, stats_depth_odd, stats_depth_even], [stats2_period, stats2_t0, stats2_duration, stats2_depth, stats2_depth_phased, stats2_depth_half, stats2_depth_odd, stats2_depth_even]
 
 # --------------------------------------------
 #                    plots                   #

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The code is designed to be fully interactive and does not require any prior know
 
 ### Installation
 
-LATTE requires python3 to be installed on your computer, which can be download from https://www.python.org/downloads/. Once you have python3, you can download the code directly from github. Alternatively, you can install LATTE using pip (https://pypi.org/project/tessLATTE/) via your command line with:
+LATTE requires python3 (SIS: try python==3.7)to be installed on your computer, which can be download from https://www.python.org/downloads/. Once you have python3, you can download the code directly from github. Alternatively, you can install LATTE using pip (https://pypi.org/project/tessLATTE/) via your command line with:
 
 	pip3 install tessLATTE      
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The code is designed to be fully interactive and does not require any prior know
 
 ### Installation
 
-LATTE requires python3 (SIS: try python==3.7)to be installed on your computer, which can be download from https://www.python.org/downloads/. Once you have python3, you can download the code directly from github. Alternatively, you can install LATTE using pip (https://pypi.org/project/tessLATTE/) via your command line with:
+LATTE requires python3 (*recommendation: `python==3.7`*) to be installed on your computer, which can be download from https://www.python.org/downloads/. Once you have python3, you can download the code directly from github. Alternatively, you can install LATTE using pip (https://pypi.org/project/tessLATTE/) via your command line with:
 
 	pip3 install tessLATTE      
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(
     "reproject > 0.7", 
     "reportlab", 
     "astropy <= 4.0",
-    "mock > 2.0.0"],
+    "mock > 2.0.0",
+    "urllib3==1.26.6"],
     entry_points={
         "console_scripts": [
             "LATTE=LATTE.__main__:main",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     "matplotlib == 3.2.0",
     "astroplan",
     "astroquery",
-    "sklearn", 
+    "scikit-learn",
     "scipy", 
     "tess-point", 
     "reproject > 0.7", 

--- a/tessLATTE.egg-info/requires.txt
+++ b/tessLATTE.egg-info/requires.txt
@@ -6,7 +6,7 @@ lightkurve>1.2.0
 matplotlib==3.2.0
 astroplan
 astroquery
-sklearn
+scikit-learn
 scipy
 tess-point
 reproject>0.7

--- a/tessLATTE.egg-info/requires.txt
+++ b/tessLATTE.egg-info/requires.txt
@@ -13,3 +13,4 @@ reproject>0.7
 reportlab
 astropy<=4.0
 mock>2.0.0
+urllib3==1.26.6


### PR DESCRIPTION
Sklearn is deprecated, therefore I updated the files `requirements.txt` and `setup.py` to use `scikit-learn` instead (https://github.com/scikit-learn/sklearn-pypi-package). I also added in the `README.md` file the suggestion of using python 3.7, since a couple of packages are only available for this python version. 

I also added a specific version of urllib3==1.26.6 to the requirements, because I was having this error "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2u  20 Dec 2019'" when installing the code in June 2024. 